### PR TITLE
Shorter table name for Oracle

### DIFF
--- a/app/models/exception_logger/logged_exception.rb
+++ b/app/models/exception_logger/logged_exception.rb
@@ -1,5 +1,6 @@
 module ExceptionLogger
   class LoggedException < ActiveRecord::Base
+    self.table_name = "logged_exceptions"
     class << self
       def create_from_exception(controller, exception, data)
         message = exception.message.inspect

--- a/db/migrate/20120507081835_create_exception_logger_logged_exceptions.rb
+++ b/db/migrate/20120507081835_create_exception_logger_logged_exceptions.rb
@@ -1,6 +1,6 @@
 class CreateExceptionLoggerLoggedExceptions < ActiveRecord::Migration
   def change
-    create_table :exception_logger_logged_exceptions, :force => true do |t|
+    create_table :logged_exceptions, :force => true do |t|
       t.string :exception_class
       t.string :controller_name
       t.string :action_name


### PR DESCRIPTION
Oracle has a 30 character limit in table names and aliases
