### PR TITLE
Resolves Out Of Memory errors

### DIFF
--- a/app/models/exception_logger/logged_exception.rb
+++ b/app/models/exception_logger/logged_exception.rb
@@ -1,6 +1,7 @@
 module ExceptionLogger
   class LoggedException < ActiveRecord::Base
     self.table_name = "logged_exceptions"
+    HOSTNAME = `hostname -s`.chomp
     class << self
       def create_from_exception(controller, exception, data)
         message = exception.message.inspect
@@ -15,7 +16,7 @@ module ExceptionLogger
       end
 
       def host_name
-        `hostname -s`.chomp
+        HOSTNAME
       end
     end
 


### PR DESCRIPTION
In production, we’re getting out of memory errors when making the system call which attempts to fork a new process. 

This change gets the hostname only once, as the class loads. It's been running in our production environment for a week now and this error is resolved there. 
